### PR TITLE
Move setPointerIcon out of onHover block

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,11 +19,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
     defaultConfig {
         applicationId "com.google.chromeos.samples.pointericon"
         minSdkVersion 24
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name="com.google.chromeos.samples.pointericon.MainActivity">
+        <activity android:name="com.google.chromeos.samples.pointericon.MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/google/chromeos/samples/pointericon/PointerViewHolder.kt
+++ b/app/src/main/java/com/google/chromeos/samples/pointericon/PointerViewHolder.kt
@@ -26,10 +26,6 @@ class PointerViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
     fun bind(pointerPair: Pair<PointerIcon, String>) {
         val pointerText = itemView.findViewById<TextView>(R.id.pointer_name)
         pointerText.text = pointerPair.second
-
-        itemView.setOnHoverListener { view, motionEvent ->
-            view.pointerIcon = pointerPair.first
-            false
-        }
+        itemView.pointerIcon = pointerPair.first
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -56,6 +56,5 @@ allprojects {
     repositories {
         google()
         jcenter()
-        
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip


### PR DESCRIPTION
On Android 14, setting the pointer icon in the onHover block can lead to the icon being constantly reset to the default. This change moves the icon change into the main bind block. setPointerIcon already considers when the mouse is being hovered over the element.

The gradle versions and target SDK have been updated as well.